### PR TITLE
Makefile: Capitalize prefix var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ OUT := pil-squasher
 
 CFLAGS ?= -Wall -g -O2
 LDFLAGS ?=
-prefix ?= /usr/local
+PREFIX ?= /usr/local
 
 SRCS := pil-squasher.c
 OBJS := $(SRCS:.c=.o)
@@ -11,7 +11,7 @@ $(OUT): $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^
 
 install: $(OUT)
-	install -D -m 755 $< $(DESTDIR)$(prefix)/bin/$<
+	install -D -m 755 $< $(DESTDIR)$(PREFIX)/bin/$<
 
 clean:
 	rm -f $(OUT) $(OBJS)


### PR DESCRIPTION
None of the others are lowercase and `PREFIX` as uppercase is the standard in most other projects.