### PR TITLE
pil-splitter: fix usage arguments

### DIFF
--- a/pil-splitter.c
+++ b/pil-splitter.c
@@ -16,7 +16,7 @@ static void usage(void)
 {
 	extern const char *__progname;
 
-	fprintf(stderr, "%s: <mbn output> <mdt header>\n", __progname);
+	fprintf(stderr, "%s: <mbn input> <mdt output>\n", __progname);
 	exit(1);
 }
 


### PR DESCRIPTION
Fix the C&P from pil-squasher and describe pil-splitter arguments properly. MBN isn't an output here.